### PR TITLE
simple support for 8 pin ATTiny MCUs

### DIFF
--- a/src/Pin.cpp
+++ b/src/Pin.cpp
@@ -19,20 +19,21 @@ struct pinMapping {
 	const uint8_t offset;  ///< Bit mask for specific pin inside register
 };
 
+/// Include the pin mappings for...
 
-// Arduino Mega
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-	#include "boards/mega.h"  ///< Include the pin mappings for the Arduino Mega
-#endif
-
-// Arduino Uno
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega168__)
-	#include "boards/uno.h"  ///< Include the pin mappings for the Arduino Uno
-#endif
-
-// Arduino Leonardo
-#if defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega16U4__)
-	#include "boards/leonardo.h"  ///< Include the pin mappings for the Arduino Leonardo
+#if   defined(__AVR_ATmega1280__) \
+   ||	defined(__AVR_ATmega2560__)				// Arduino Mega
+#include "boards/mega.h"
+#elif defined(__AVR_ATmega328P__) \
+	 ||	defined(__AVR_ATmega168__)				// Arduino Uno
+#include "boards/uno.h"
+#elif defined(__AVR_ATmega32U4__) \
+	 || defined(__AVR_ATmega16U4__)				// Arduino Leonardo
+#include "boards/leonardo.h"
+#elif defined(__AVR_ATtiny25__) 	\
+   || defined(__AVR_ATtiny45__) 	\
+   ||	defined(__AVR_ATtiny85__)					// ATTiny25/45/85
+#include "boards/attinyX5.h"
 #endif
 
 

--- a/src/boards/attinyX5.h
+++ b/src/boards/attinyX5.h
@@ -1,0 +1,25 @@
+/**
+	@file attinyX5.h
+	@author Alexc Gray
+	@brief attinyX5 pin mappings
+ */
+
+#pragma once
+
+#define ANALOGOFFSET 3  // Where, in this struct, is the index of the first analog pin?
+
+/**
+	Pin mappings for the attinyX5 MCU/IC
+	@note All the pins on the tiny 25/45/85 are within Register B!
+ */
+
+struct pinMapping pinMappings[] =
+{
+	{REGB,1<<0}, 	// Digital
+	{REGB,1<<1},
+
+	{REGB,1<<2}, 	// Analog
+	{REGB,1<<3},
+	{REGB,1<<4},
+};
+


### PR DESCRIPTION
Also, tidies #include guards.  PS...  Why not just `#include boards.h` and then do "the checks" in that ONE header?  Better yet.. why don't we glean this info from existing infrastructure like `pins_arduino.h`, instead??  (Much more maintainable, especially considering how cryptic the nature of this struct is...  
